### PR TITLE
Pathology/simplifier fixes

### DIFF
--- a/examples/Pathology-Bundle-GTT-Report-Example.xml
+++ b/examples/Pathology-Bundle-GTT-Report-Example.xml
@@ -293,82 +293,6 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:45f1e625-9af2-4920-9ac4-63b4d9d30bd0" />
-    <resource>
-      <Specimen>
-        <id value="45f1e625-9af2-4920-9ac4-63b4d9d30bd0" />
-        <meta>
-          <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Specimen" />
-        </meta>
-        <identifier>
-          <system value="http://B82033-pickeringmedicalpractice.com/specimen" />
-          <value value="SPC-REQ-20220209-000083" />
-        </identifier>
-        <accessionIdentifier>
-          <system value="http://Y8J7D-pathlab001.com/specimen" />
-          <value value="SPC-LAB-20220209-001549" />
-        </accessionIdentifier>
-        <status value="available" />
-        <type>
-          <coding>
-            <system value="http://snomed.info/sct" />
-            <code value="122555007" />
-            <display value="Venous blood specimen" />
-          </coding>
-        </type>
-        <subject>
-          <reference value="urn:uuid:ab87a3f8-1d37-44a9-804e-5e962598a6e4" />
-          <display value="MOXEY, Judy" />
-        </subject>
-        <receivedTime value="2022-02-09T14:17:06+00:00" />
-        <request>
-          <reference value="urn:uuid:1c38d507-9ad7-4b49-ba91-7da204842cac" />
-        </request>
-        <collection>
-          <collectedDateTime value="2022-02-09T11:03:07+00:00" />
-        </collection>
-      </Specimen>
-    </resource>
-  </entry>
-  <entry>
-    <fullUrl value="urn:uuid:ad717ae8-cb35-4d66-ba51-e22a76b1d158" />
-    <resource>
-      <Specimen>
-        <id value="ad717ae8-cb35-4d66-ba51-e22a76b1d158" />
-        <meta>
-          <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Specimen" />
-        </meta>
-        <identifier>
-          <system value="http://B82033-pickeringmedicalpractice.com/specimen" />
-          <value value="SPC-REQ-20220209-000084" />
-        </identifier>
-        <accessionIdentifier>
-          <system value="http://Y8J7D-pathlab001.com/specimen" />
-          <value value="SPC-LAB-20220209-001587" />
-        </accessionIdentifier>
-        <status value="available" />
-        <type>
-          <coding>
-            <system value="http://snomed.info/sct" />
-            <code value="122555007" />
-            <display value="Venous blood specimen" />
-          </coding>
-        </type>
-        <subject>
-          <reference value="urn:uuid:ab87a3f8-1d37-44a9-804e-5e962598a6e4" />
-          <display value="MOXEY, Judy" />
-        </subject>
-        <receivedTime value="2022-02-09T14:17:06+00:00" />
-        <request>
-          <reference value="urn:uuid:1c38d507-9ad7-4b49-ba91-7da204842cac" />
-        </request>
-        <collection>
-          <collectedDateTime value="2022-02-09T12:02:17+00:00" />
-        </collection>
-      </Specimen>
-    </resource>
-  </entry>
-  <entry>
     <fullUrl value="urn:uuid:2a48660b-8d45-4735-acaa-3d9918b6b902" />
     <resource>
       <Observation>
@@ -627,6 +551,82 @@
           <reference value="urn:uuid:ad717ae8-cb35-4d66-ba51-e22a76b1d158" />
         </specimen>
       </Observation>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="urn:uuid:45f1e625-9af2-4920-9ac4-63b4d9d30bd0" />
+    <resource>
+      <Specimen>
+        <id value="45f1e625-9af2-4920-9ac4-63b4d9d30bd0" />
+        <meta>
+          <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Specimen" />
+        </meta>
+        <identifier>
+          <system value="http://B82033-pickeringmedicalpractice.com/specimen" />
+          <value value="SPC-REQ-20220209-000083" />
+        </identifier>
+        <accessionIdentifier>
+          <system value="http://Y8J7D-pathlab001.com/specimen" />
+          <value value="SPC-LAB-20220209-001549" />
+        </accessionIdentifier>
+        <status value="available" />
+        <type>
+          <coding>
+            <system value="http://snomed.info/sct" />
+            <code value="122555007" />
+            <display value="Venous blood specimen" />
+          </coding>
+        </type>
+        <subject>
+          <reference value="urn:uuid:ab87a3f8-1d37-44a9-804e-5e962598a6e4" />
+          <display value="MOXEY, Judy" />
+        </subject>
+        <receivedTime value="2022-02-09T14:17:06+00:00" />
+        <request>
+          <reference value="urn:uuid:1c38d507-9ad7-4b49-ba91-7da204842cac" />
+        </request>
+        <collection>
+          <collectedDateTime value="2022-02-09T11:03:07+00:00" />
+        </collection>
+      </Specimen>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="urn:uuid:ad717ae8-cb35-4d66-ba51-e22a76b1d158" />
+    <resource>
+      <Specimen>
+        <id value="ad717ae8-cb35-4d66-ba51-e22a76b1d158" />
+        <meta>
+          <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Specimen" />
+        </meta>
+        <identifier>
+          <system value="http://B82033-pickeringmedicalpractice.com/specimen" />
+          <value value="SPC-REQ-20220209-000084" />
+        </identifier>
+        <accessionIdentifier>
+          <system value="http://Y8J7D-pathlab001.com/specimen" />
+          <value value="SPC-LAB-20220209-001587" />
+        </accessionIdentifier>
+        <status value="available" />
+        <type>
+          <coding>
+            <system value="http://snomed.info/sct" />
+            <code value="122555007" />
+            <display value="Venous blood specimen" />
+          </coding>
+        </type>
+        <subject>
+          <reference value="urn:uuid:ab87a3f8-1d37-44a9-804e-5e962598a6e4" />
+          <display value="MOXEY, Judy" />
+        </subject>
+        <receivedTime value="2022-02-09T14:17:06+00:00" />
+        <request>
+          <reference value="urn:uuid:1c38d507-9ad7-4b49-ba91-7da204842cac" />
+        </request>
+        <collection>
+          <collectedDateTime value="2022-02-09T12:02:17+00:00" />
+        </collection>
+      </Specimen>
     </resource>
   </entry>
 </Bundle>

--- a/examples/Pathology-Bundle-Urine-MCS-01-Report-Example.xml
+++ b/examples/Pathology-Bundle-Urine-MCS-01-Report-Example.xml
@@ -193,44 +193,6 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:bde5b0a5-4fb3-4655-acf0-215b93aee006" />
-    <resource>
-      <Specimen>
-        <id value="bde5b0a5-4fb3-4655-acf0-215b93aee006" />
-        <meta>
-          <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Specimen" />
-        </meta>
-        <identifier>
-          <system value="http://B82033-pickeringmedicalpractice.com/specimen" />
-          <value value="SPC-REQ-20220221-000024" />
-        </identifier>
-        <accessionIdentifier>
-          <system value="http://Y8J7D-pathlab001.com/specimen" />
-          <value value="SPC-LAB-20220221-004306" />
-        </accessionIdentifier>
-        <status value="available" />
-        <type>
-          <coding>
-            <system value="http://snomed.info/sct" />
-            <code value="122575003" />
-            <display value="Urine specimen" />
-          </coding>
-        </type>
-        <subject>
-          <reference value="urn:uuid:ab87a3f8-1d37-44a9-804e-5e962598a6e4" />
-          <display value="MOXEY, Judy" />
-        </subject>
-        <receivedTime value="2022-02-21T14:58:00+00:00" />
-        <request>
-          <reference value="urn:uuid:1c38d507-9ad7-4b49-ba91-7da204842cac" />
-        </request>
-        <collection>
-          <collectedDateTime value="2022-02-21T11:07:00+00:00" />
-        </collection>
-      </Specimen>
-    </resource>
-  </entry>
-  <entry>
     <fullUrl value="urn:uuid:35d46ca1-f253-4c97-b7ee-fb5fccdf6c20" />
     <resource>
       <DiagnosticReport>
@@ -901,6 +863,44 @@
           <reference value="urn:uuid:bde5b0a5-4fb3-4655-acf0-215b93aee006" />
         </specimen>
       </Observation>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="urn:uuid:bde5b0a5-4fb3-4655-acf0-215b93aee006" />
+    <resource>
+      <Specimen>
+        <id value="bde5b0a5-4fb3-4655-acf0-215b93aee006" />
+        <meta>
+          <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Specimen" />
+        </meta>
+        <identifier>
+          <system value="http://B82033-pickeringmedicalpractice.com/specimen" />
+          <value value="SPC-REQ-20220221-000024" />
+        </identifier>
+        <accessionIdentifier>
+          <system value="http://Y8J7D-pathlab001.com/specimen" />
+          <value value="SPC-LAB-20220221-004306" />
+        </accessionIdentifier>
+        <status value="available" />
+        <type>
+          <coding>
+            <system value="http://snomed.info/sct" />
+            <code value="122575003" />
+            <display value="Urine specimen" />
+          </coding>
+        </type>
+        <subject>
+          <reference value="urn:uuid:ab87a3f8-1d37-44a9-804e-5e962598a6e4" />
+          <display value="MOXEY, Judy" />
+        </subject>
+        <receivedTime value="2022-02-21T14:58:00+00:00" />
+        <request>
+          <reference value="urn:uuid:1c38d507-9ad7-4b49-ba91-7da204842cac" />
+        </request>
+        <collection>
+          <collectedDateTime value="2022-02-21T11:07:00+00:00" />
+        </collection>
+      </Specimen>
     </resource>
   </entry>
 </Bundle>

--- a/examples/Pathology-DiagnosticReport-Lab-Sn-Example.xml
+++ b/examples/Pathology-DiagnosticReport-Lab-Sn-Example.xml
@@ -1,4 +1,4 @@
-<DiagnosticReport>
+<DiagnosticReport xmlns="http://hl7.org/fhir">
   <id value="Pathology-DiagnosticReport-Lab-Sn-Example" />
   <!-- The canonical URL for the UKCore-DiagnosticReport-Lab profile. -->
   <meta>

--- a/examples/Pathology-Observation-Aerobic-Culture-Example.xml
+++ b/examples/Pathology-Observation-Aerobic-Culture-Example.xml
@@ -1,4 +1,4 @@
- <Observation xmlns="http://hl7.org/fhir">
+<Observation xmlns="http://hl7.org/fhir">
   <id value="Pathology-Observation-Aerobic-Culture-Example" />
   <meta>
     <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-Lab" />

--- a/examples/Pathology-Observation-Aerobic-Culture-Example.xml
+++ b/examples/Pathology-Observation-Aerobic-Culture-Example.xml
@@ -1,4 +1,4 @@
- <Observation>
+ <Observation xmlns="http://hl7.org/fhir">
   <id value="Pathology-Observation-Aerobic-Culture-Example" />
   <meta>
     <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-Lab" />

--- a/examples/Pathology-Observation-Albumin-Example.xml
+++ b/examples/Pathology-Observation-Albumin-Example.xml
@@ -1,4 +1,4 @@
-<Observation>
+<Observation xmlns="http://hl7.org/fhir">
   <id value="Pathology-Observation-Albumin-Example" />
   <meta>
     <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-Lab" />

--- a/examples/Pathology-Observation-Epithelial-Cells-Example.xml
+++ b/examples/Pathology-Observation-Epithelial-Cells-Example.xml
@@ -1,4 +1,4 @@
-<Observation>
+<Observation xmlns="http://hl7.org/fhir">
   <id value="Pathology-Observation-Epithelial-Cells-Example" />
   <meta>
     <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-Lab" />

--- a/examples/Pathology-Observation-Group-Lab-Sn-Example.xml
+++ b/examples/Pathology-Observation-Group-Lab-Sn-Example.xml
@@ -1,4 +1,4 @@
-<Observation>
+<Observation xmlns="http://hl7.org/fhir">
   <id value="Pathology-Observation-Group-Lab-Sn-Example" />
   <!-- The canonical URL for the UKCore-Observation-Group-Lab profile. -->
   <meta>

--- a/examples/Pathology-Observation-HBsAg-Example.xml
+++ b/examples/Pathology-Observation-HBsAg-Example.xml
@@ -1,4 +1,4 @@
-<Observation>
+<Observation xmlns="http://hl7.org/fhir">
   <id value="Pathology-Observation-HBsAg-Example" />
   <meta>
     <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-Lab" />

--- a/examples/Pathology-Observation-Lab-Sn-Example.xml
+++ b/examples/Pathology-Observation-Lab-Sn-Example.xml
@@ -1,4 +1,4 @@
-<Observation>
+<Observation xmlns="http://hl7.org/fhir">
   <id value="Pathology-Observation-Lab-Sn-Example" />
   <!-- The canonical URL for the UKCore-Observation-Lab profile. -->
   <meta>

--- a/examples/Pathology-Observation-Lymphocyte-Example.xml
+++ b/examples/Pathology-Observation-Lymphocyte-Example.xml
@@ -1,4 +1,4 @@
-<Observation>
+<Observation xmlns="http://hl7.org/fhir">
   <id value="Pathology-Observation-Lymphocyte-Example" />
   <meta>
     <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-Lab" />

--- a/examples/Pathology-Observation-MRSA-Example.xml
+++ b/examples/Pathology-Observation-MRSA-Example.xml
@@ -1,4 +1,4 @@
-<Observation>
+<Observation xmlns="http://hl7.org/fhir">
   <id value="Pathology-Observation-MRSA-Example" />
   <meta>
     <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-Lab" />

--- a/examples/Pathology-Observation-Nitrofurantoin-Susceptibility-Example.xml
+++ b/examples/Pathology-Observation-Nitrofurantoin-Susceptibility-Example.xml
@@ -1,4 +1,4 @@
-<Observation>
+<Observation xmlns="http://hl7.org/fhir">
   <id value="Pathology-Observation-Nitrofurantoin-Susceptibility-Example" />
   <meta>
     <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-Lab" />

--- a/examples/Pathology-Observation-Rubella-Example.xml
+++ b/examples/Pathology-Observation-Rubella-Example.xml
@@ -1,4 +1,4 @@
-<Observation>
+<Observation xmlns="http://hl7.org/fhir">
   <id value="Pathology-Observation-Rubella-Example" />
   <meta>
     <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-Lab" />

--- a/examples/Pathology-Observation-eGFR-Example.xml
+++ b/examples/Pathology-Observation-eGFR-Example.xml
@@ -1,4 +1,4 @@
-<Observation>
+<Observation xmlns="http://hl7.org/fhir">
   <id value="Pathology-Observation-eGFR-Example" />
   <meta>
     <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-Lab" />

--- a/examples/Pathology-ServiceRequest-Lab-Sn-Example.xml
+++ b/examples/Pathology-ServiceRequest-Lab-Sn-Example.xml
@@ -1,4 +1,4 @@
-<ServiceRequest>
+<ServiceRequest xmlns="http://hl7.org/fhir">
   <id value="Pathology-ServiceRequest-Lab-Sn-Example" />
   <!-- The canonical URL for the UKCore-ServiceRequest-Lab profile. -->
   <meta>

--- a/examples/Pathology-Specimen-Sn-Example.xml
+++ b/examples/Pathology-Specimen-Sn-Example.xml
@@ -1,4 +1,4 @@
-<Specimen>
+<Specimen xmlns="http://hl7.org/fhir">
   <id value="Pathology-Specimen-Sn-Example" />
   <!-- The canonical URL for the UKCore-Specimen profile. -->
   <meta>


### PR DESCRIPTION
- Changed order of resources in bundle to match the England-Pathology-Report message definition
- Added  xmlns="http://hl7.org/fhir">to line 1 so that it reads <[resource]  xmlns="http://hl7.org/fhir">

as per https://www.hl7.org/fhir/R4/xml.html