### PR TITLE
Update Package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "uk.nhsengland.r4",
-  "description": "NHS England FHIR Implementation Guide",
+  "description": "NHS England Programme Implementation Guides",
   "author": "nhsengland",
   "version": "0.0.1",
   "dependencies": {
     "hl7.fhir.r4.core": "4.0.1",
-    "fhir.r4.nhsengland.stu1": "1.2.0",
+    "fhir.r4.nhsengland.stu1": "1.2.1",
     "fhir.r4.ukcore.stu3.currentbuild": "0.0.9-pre-release"
   },
   "fhirVersions": [


### PR DESCRIPTION
Updated the description and NHSE IG dependency version.
- Update dependency package for NHS England Programme Implementation Guides.
- The specific dependency package is for NHS England Implementation Guide, its latest fhir.r4.nhsengland.stu1/1.2.1
This is to enable some assets render in DoS IG.
Affected Assets include: 
- England Message Events BARS
- ValueSet-NHSDigitalMessageEvent. Some issues with this ValueSet has been flagged to NHSE IG Dev. Team