### PR TITLE
Healthcare workerer api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.idea/aws.xml
+.idea/misc.xml
+.idea/modules.xml
+.idea/NHSEngland-FHIR-Programme-ImplementationGuide.iml
+.idea/vcs.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/CapabilityStatement/CapabilityStatement-England-Healthcare-Worker-Requirements.json
+++ b/CapabilityStatement/CapabilityStatement-England-Healthcare-Worker-Requirements.json
@@ -1,0 +1,92 @@
+{
+    "resourceType" : "CapabilityStatement",
+    "id" : "England-Healthcare-Worker-Requirements",
+    "url" : "https://fhir.nhs.uk/England/CapabilityStatement/England-Healthcare-Worker-Requirements",
+    "version" : "0.0.1-current",
+    "name" : "EnglandHealthcareWorkerRequirements",
+    "title" : "England Healthcare Worker Requirements",
+    "status" : "draft",
+    "experimental" : false,
+    "date" : "2024-10-08",
+    "publisher" : "NHS England",
+    "contact":  [
+      {
+          "name": "NHS England",
+          "telecom":  [
+              {
+                  "system": "email",
+                  "value": "interoperabilityteam@nhs.net",
+                  "use": "work",
+                  "rank": 1
+              }
+          ]
+      }
+  ],
+    "description" : "This is for description purposes only and will be replaced by the OAS specification.\n",
+    "copyright": "Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the \"License\"); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html.",
+    "kind" : "requirements",
+    "fhirVersion" : "4.0.1",
+    "format" : [
+      "application/fhir+xml",
+      "application/fhir+json"
+    ],
+    "rest" : [
+      {
+        "mode" : "server",
+        "resource" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode" : "SHALL"
+              }
+            ],
+            "type" : "Practitioner",
+            "profile" : "https://fhir.nhs.uk/England/StructureDefinition/England-Practitioner",
+            "supportedProfile" : [
+              "https://fhir.hl7.org.uk/StructureDefinition/UKCore-Practitioner"
+            ],
+            "documentation" : "\n```\nGET /Practitioner?{parameters}\n```\n\nConformance to this implementation guide **SHOULD** be tested via [FHIR Validation](https://hl7.org/fhir/R4/validation.html).\n\n**Search Examples**\n\nSearch for Practitioner with a SDS User Id = 3415870201\n\n```\nGET /Practitioner?identifier=https://fhir.nhs.uk/Id/sds-user-id|3415870201\n```\n",
+            "interaction" : [
+              {
+                "code" : "search-type"
+              }
+            ],
+            "searchParam" : [
+              {
+                "name" : "identifier",
+                "type" : "token",
+                "documentation" : "A practitioner's Identifier"
+              }
+            ]
+          },
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode" : "SHALL"
+              }
+            ],
+            "type" : "PractitionerRole",
+            "profile" : "https://fhir.nhs.uk/England/StructureDefinition/England-PractitionerRole-Healthcare-Worker",
+            "supportedProfile" : [
+              "https://fhir.hl7.org.uk/StructureDefinition/UKCore-PractitionerRole"
+            ],
+            "documentation" : "\n```\nGET /PractitionerRole?{parameters}\n```\n\nConformance to this implementation guide **SHOULD** be tested via [FHIR Validation](https://hl7.org/fhir/R4/validation.html).\n\n**Search Examples**\n\nSearch for PractitionerRole with a SDS User Profile Id = 454567759542\n\n```\nGET /PractitionerRole?identifier=https://fhir.nhs.uk/Id/sds-role-profile-id|454567759542\n```\n",
+            "interaction" : [
+              {
+                "code" : "search-type"
+              }
+            ],
+            "searchParam" : [
+              {
+                "name" : "identifier",
+                "type" : "token",
+                "documentation" : "A practitioner's Identifier"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }

--- a/codesystems/CodeSystem-England-JobRoleCode.xml
+++ b/codesystems/CodeSystem-England-JobRoleCode.xml
@@ -1,0 +1,32 @@
+<CodeSystem xmlns="http://hl7.org/fhir">
+    <id value="England-JobRoleCode" />
+    <url value="https://fhir.nhs.uk/England/CodeSystem/England-JobRoleCode" />
+    <version value="0.0.1" />
+    <name value="EnglandJobRoleCode" />
+    <title value ="England Job Role Code" />
+    <status value="draft" />
+    <date value="2024-10-26" />
+    <publisher value="NHS England" />
+    <description value="[JOB ROLE CODE](https://www.datadictionary.nhs.uk/attributes/job_role_code.html)" />
+    <contact>
+      <name value="NHS England" />
+      <telecom>
+        <system value="email" />
+        <value value="interoperabilityteam@nhs.net" />
+        <use value="work" />
+        <rank value="1" />
+      </telecom>
+    </contact>
+    <copyright value="Copyright © 2024+ NHS England Licensed under the Apache License, Version 2.0 (the \&quot;License\&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \&quot;AS IS\&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+    <caseSensitive value="true" />
+    <content value="fragment" />
+    <concept>
+        <code value="01025" />
+        <display value="Medical and Dental - GENERAL MEDICAL PRACTITIONER" />
+    </concept>
+      <concept>
+        <code value="01005" />
+        <display value="Medical and Dental - CONSULTANT" />
+    </concept>
+    
+</CodeSystem>

--- a/examples/Healthcare-Worker-Bundle-Search-Practitioner-Example.json
+++ b/examples/Healthcare-Worker-Bundle-Search-Practitioner-Example.json
@@ -1,0 +1,48 @@
+{
+    "resourceType" : "Bundle",
+    "id" : "Healthcare-Worker-Bundle-Search-Practitioner-Example",
+    "type" : "searchset",
+    "total" : 1,
+    "link" : [
+      {
+        "relation" : "self",
+        "url" : "https://directoryservices.example.nhs.uk/FHIR/R4/Practitioner?identifier=https://fhir.nhs.uk/Id/sds-user-id|3415870201"
+      }
+    ],
+    "entry" : [
+      {
+        "fullUrl" : "https://directoryservices.example.nhs.uk/FHIR/R4/Practitioner/Healthcare-Worker-Practitioner-GP-Example",
+        "resource" : {
+          "resourceType" : "Practitioner",
+          "id" : "Healthcare-Worker-Practitioner-GP-Example",
+          "identifier" : [
+            {
+              "system" : "https://fhir.nhs.uk/Id/sds-user-id",
+              "value" : "3415870201"
+            },
+            {
+              "use" : "usual",
+              "system" : "https://fhir.hl7.org.uk/Id/gmp-number",
+              "value" : "G1234567"
+            }
+          ],
+          "active" : true,
+          "name" : [
+            {
+              "use" : "official",
+              "family" : "ALI",
+              "given" : [
+                "RAZIA"
+              ],
+              "prefix" : [
+                "Dr"
+              ]
+            }
+          ]
+        },
+        "search" : {
+          "mode" : "match"
+        }
+      }
+    ]
+  }

--- a/examples/Healthcare-Worker-Bundle-Search-PractitionerRole-Example.json
+++ b/examples/Healthcare-Worker-Bundle-Search-PractitionerRole-Example.json
@@ -1,0 +1,67 @@
+{
+  "resourceType": "Bundle",
+  "id": "Healthcare-Worker-Bundle-Search-PractitionerRole-Example",
+  "type": "searchset",
+  "total": 1,
+  "link": [
+    {
+      "relation": "self",
+      "url": "https://directoryservice.example.nhs.uk/FHIR/R4/PractitionerRole?identifier=https://fhir.nhs.uk/Id/sds-role-profile-id|454567759542"
+    }
+  ],
+  "entry": [
+    {
+      "fullUrl": "https://directoryservice.example.nhs.uk/FHIR/R4/PractitionerRole/Healthcare-Worker-PractitionerRole-Consultant-Example",
+      "resource": {
+        "resourceType": "PractitionerRole",
+        "id": "Healthcare-Worker-PractitionerRole-Consultant-Example",
+        "identifier": [
+          {
+            "system": "https://fhir.nhs.uk/Id/sds-role-profile-id",
+            "value": "454567759542"
+          }
+        ],
+        "active": true,
+        "period": {
+          "start": "2024-09-30"
+        },
+        "practitioner": {
+          "reference": "https://fhir.nhs.uk/England/spine/Practitioner/practitioner-consultant",
+          "identifier": {
+            "system": "https://fhir.hl7.org.uk/Id/gmc-number",
+            "value": "C4428981"
+          },
+          "display": "Dr Thomas Edwards"
+        },
+        "organization": {
+          "identifier": {
+            "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+            "value": "RBA"
+          },
+          "display": "TAUNTON AND SOMERSET NHS FOUNDATION TRUST"
+        },
+        "code": [
+          {
+            "coding": [
+              {
+                "system": "https://fhir.nhs.uk/England/CodeSystem/England-JobRoleCode",
+                "code": "01005"
+              }
+            ]
+          },
+          {
+            "coding": [
+              {
+                "system": "https://fhir.nhs.uk/England/CodeSystem/England-SDSJobRoleName",
+                "code": "R0620"
+              }
+            ]
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    }
+  ]
+}

--- a/examples/Healthcare-Worker-Practitioner-Consultant-Example.json
+++ b/examples/Healthcare-Worker-Practitioner-Consultant-Example.json
@@ -1,0 +1,28 @@
+{
+    "resourceType" : "Practitioner",
+    "id" : "Healthcare-Worker-Practitioner-Consultant-Example",
+    "identifier" : [
+      {
+        "system" : "https://fhir.nhs.uk/Id/sds-user-id",
+        "value" : "3415870202"
+      },
+      {
+        "use" : "usual",
+        "system" : "https://fhir.hl7.org.uk/Id/gmc-number",
+        "value" : "C4428981"
+      }
+    ],
+    "active" : false,
+    "name" : [
+      {
+        "use" : "official",
+        "family" : "Edwards",
+        "given" : [
+          "Thomas"
+        ],
+        "prefix" : [
+          "Dr"
+        ]
+      }
+    ]
+  }

--- a/examples/Healthcare-Worker-Practitioner-GP-Example.json
+++ b/examples/Healthcare-Worker-Practitioner-GP-Example.json
@@ -1,0 +1,28 @@
+{
+    "resourceType" : "Practitioner",
+    "id" : "Healthcare-Worker-Practitioner-GP-Example",
+    "identifier" : [
+      {
+        "system" : "https://fhir.nhs.uk/Id/sds-user-id",
+        "value" : "3415870201"
+      },
+      {
+        "use" : "usual",
+        "system" : "https://fhir.hl7.org.uk/Id/gmp-number",
+        "value" : "G1234567"
+      }
+    ],
+    "active" : true,
+    "name" : [
+      {
+        "use" : "official",
+        "family" : "ALI",
+        "given" : [
+          "RAZIA"
+        ],
+        "prefix" : [
+          "Dr"
+        ]
+      }
+    ]
+  }

--- a/examples/Healthcare-Worker-PractitionerRole-Consultant-Example.json
+++ b/examples/Healthcare-Worker-PractitionerRole-Consultant-Example.json
@@ -1,0 +1,48 @@
+{
+  "resourceType": "PractitionerRole",
+  "id": "Healthcare-Worker-PractitionerRole-Consultant-Example",
+  "identifier": [
+    {
+      "system": "https://fhir.nhs.uk/Id/sds-role-profile-id",
+      "value": "454567759542"
+    }
+  ],
+  "active": true,
+  "period": {
+    "start": "2024-09-30"
+  },
+  "practitioner": {
+    "reference": "https://directoryservice.example.nhs.uk/FHIR/R4/Practitioner/Healthcare-Worker-Practitioner-Consultant-Example",
+    "identifier": {
+      "system": "https://fhir.hl7.org.uk/Id/gmc-number",
+      "value": "C4428981"
+    },
+    "display": "Dr Thomas Edwards"
+  },
+  "organization": {
+    "reference": "https://directoryservice.example.nhs.uk/FHIR/R4/Organization/RBA",
+    "identifier": {
+      "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+      "value": "RBA"
+    },
+    "display": "TAUNTON AND SOMERSET NHS FOUNDATION TRUST"
+  },
+  "code": [
+    {
+      "coding": [
+        {
+          "system": "https://fhir.nhs.uk/England/CodeSystem/England-JobRoleCode",
+          "code": "01005"
+        }
+      ]
+    },
+    {
+      "coding": [
+        {
+          "system": "https://fhir.nhs.uk/England/CodeSystem/England-SDSJobRoleName",
+          "code": "R0620"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/Healthcare-Worker-PractitionerRole-GP-Example.json
+++ b/examples/Healthcare-Worker-PractitionerRole-GP-Example.json
@@ -1,0 +1,47 @@
+{
+    "resourceType" : "PractitionerRole",
+    "id" : "Healthcare-Worker-PractitionerRole-GP-Example",
+    "identifier" : [
+      {
+        "system" : "https://fhir.nhs.uk/Id/sds-role-profile-id",
+        "value" : "125686540025"
+      }
+    ],
+    "active" : true,
+    "period" : {
+      "start" : "2024-09-30"
+    },
+    "practitioner" : {
+       "reference" : "https://directoryservice.example.nhs.uk/FHIR/R4/Practitioner/Healthcare-Worker-Practitioner-GP-Example",
+      "identifier" : {
+        "system" : "https://fhir.nhs.uk/Id/sds-user-id",
+        "value" : "3415870201"
+      },
+      "display" : "Dr Razia Ali"
+    },
+    "organization" : {
+      "reference" : "https://directoryservice.example.nhs.uk/FHIR/R4/Organization/M85011",
+      "identifier" : {
+        "system" : "https://fhir.nhs.uk/Id/ods-organization-code",
+        "value" : "M85011"
+      },
+      "display" : "THE SWAN MEDICAL CENTRE"
+    },
+    "code" : [
+      {
+        "coding" : [
+          {
+            "system" : "https://fhir.nhs.uk/England/CodeSystem/England-JobRoleCode",
+            "code" : "01025"
+          }
+        ]
+      },
+      {
+        "coding" : [
+          {
+            "system" : "https://fhir.nhs.uk/England/CodeSystem/England-SDSJobRoleName",
+            "code" : "R0260"
+          }
+        ]
+    ]
+  }

--- a/structuredefinitions/England-Identifier-General-Medical-Council-Reference-Number.xml
+++ b/structuredefinitions/England-Identifier-General-Medical-Council-Reference-Number.xml
@@ -1,0 +1,47 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="England-Identifier-General-Medical-Council-Reference-Number" />
+  <url
+       value="https://fhir.nhs.uk/England/StructureDefinition/England-Identifier-General-Medical-Council-Reference-Number" />
+  <version value="0.0.1-current" />
+  <name value="EnglandIdentifierGeneralMedicalCouncilReferenceNumber" />
+  <title value="England Identifier General Medical Council Reference Number" />
+  <status value="draft" />
+  <date value="2024-10-25T07:31:19+00:00" />
+  <publisher value="NHS England" />
+  <contact>
+    <name value="NHS England" />
+    <telecom>
+      <system value="email" />
+      <value value="interoperabilityteam@nhs.net" />
+      <use value="work" />
+      <rank value="1" />
+    </telecom>
+  </contact>
+  <description
+               value="[GENERAL MEDICAL COUNCIL REFERENCE NUMBER](https://www.datadictionary.nhs.uk/attributes/general_medical_council_reference_number.html) which is a [CONSULTANT CODE](https://www.datadictionary.nhs.uk/data_elements/consultant_code.html)
+
+Format CNNNNNNN
+
+- HL7 v3/OID: 2.16.840.1.113883.2.1.3.2.4.16.63
+- HL7 v2: GMC
+- HL7 FHIR https://fhir.hl7.org.uk/Id/gmc-number" />
+<purpose value="This documents NHS England Data Dictionary and HL7 definitions" />
+  <copyright value="Copyright © 2023+ NHS England Licensed under the Apache License, Version 2.0 (the \&amp;quot;License\&amp;quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \&amp;quot;AS IS\&amp;quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+  <fhirVersion value="4.0.1" />
+  <kind value="complex-type" />
+  <abstract value="false" />
+  <type value="Identifier" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Identifier" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Identifier.system">
+      <path value="Identifier.system" />
+      <min value="1" />
+      <patternUri value="https://fhir.hl7.org.uk/Id/gmc-number" />
+    </element>
+    <element id="Identifier.value">
+      <path value="Identifier.value" />
+      <min value="1" />
+    </element>
+  </differential>
+</StructureDefinition>

--- a/structuredefinitions/England-Identifier-General-Medical-Practitioner-Code.xml
+++ b/structuredefinitions/England-Identifier-General-Medical-Practitioner-Code.xml
@@ -1,0 +1,46 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="England-Identifier-General-Medical-Practitioner-Code" />
+  <url
+       value="https://fhir.nhs.uk/England/StructureDefinition/England-Identifier-General-Medical-Practitioner-Code" />
+  <version value="0.0.1-current" />
+  <name value="EnglandIdentifierGeneralMedicalPractitionerCode" />
+  <title value="England Identifier General Medical Practitioner Code" />
+  <status value="draft" />
+  <date value="2024-10-25T07:31:19+00:00" />
+  <publisher value="NHS England" />
+  <contact>
+    <name value="NHS England" />
+    <telecom>
+      <system value="email" />
+      <value value="interoperabilityteam@nhs.net" />
+      <use value="work" />
+      <rank value="1" />
+    </telecom>
+  </contact>
+  <description
+               value="[GENERAL MEDICAL PRACTITIONER PPD CODE](https://www.datadictionary.nhs.uk/attributes/general_medical_practitioner_ppd_code.html). Formerly called GP General National Code (GNC).
+
+Format G[1234589]NNNNNN
+
+HL7 v3/OID: 2.16.840.1.113883.2.1.3.2.4.16.62
+HL7 v2: GMP" />
+<purpose value="This documents NHS England Data Dictionary and HL7 definitions" />
+  <copyright value="Copyright © 2023+ NHS England Licensed under the Apache License, Version 2.0 (the \&amp;quot;License\&amp;quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \&amp;quot;AS IS\&amp;quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+  <fhirVersion value="4.0.1" />
+  <kind value="complex-type" />
+  <abstract value="false" />
+  <type value="Identifier" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Identifier" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Identifier.system">
+      <path value="Identifier.system" />
+      <min value="1" />
+      <patternUri value="https://fhir.hl7.org.uk/Id/gmp-number" />
+    </element>
+    <element id="Identifier.value">
+      <path value="Identifier.value" />
+      <min value="1" />
+    </element>
+  </differential>
+</StructureDefinition>

--- a/structuredefinitions/England-Identifier-Organisation-Code.xml
+++ b/structuredefinitions/England-Identifier-Organisation-Code.xml
@@ -1,0 +1,39 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="England-Identifier-Organisation-Code" />
+  <url value="https://fhir.nhs.uk/England/StructureDefinition/England-Identifier-Organisation-Code" />
+  <version value="0.0.1-current" />
+  <name value="EnglandIdentifierOrganisationCode" />
+  <title value="England Identifier Organisation Code" />
+  <status value="draft" />
+  <date value="2024-10-25T07:31:19+00:00" />
+  <publisher value="NHS England" />
+  <contact>
+    <name value="NHS England" />
+    <telecom>
+      <system value="email" />
+      <value value="interoperabilityteam@nhs.net" />
+      <use value="work" />
+      <rank value="1" />
+    </telecom>
+  </contact>
+  <description value="NHS Data Dictionary [ORGANISATION_CODE](https://www.datadictionary.nhs.uk/attributes/organisation_code.html)" />
+  <purpose value="This documents NHS England Data Dictionary and HL7 definitions" />
+  <copyright value="Copyright © 2023+ NHS England Licensed under the Apache License, Version 2.0 (the \&amp;quot;License\&amp;quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \&amp;quot;AS IS\&amp;quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+  <fhirVersion value="4.0.1" />
+  <kind value="complex-type" />
+  <abstract value="false" />
+  <type value="Identifier" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Identifier" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Identifier.system">
+      <path value="Identifier.system" />
+      <min value="1" />
+      <patternUri value="https://fhir.nhs.uk/Id/ods-organization-code" />
+    </element>
+    <element id="Identifier.value">
+      <path value="Identifier.value" />
+      <min value="1" />
+    </element>
+  </differential>
+</StructureDefinition>

--- a/structuredefinitions/England-Identifier-SDS-User-Id.xml
+++ b/structuredefinitions/England-Identifier-SDS-User-Id.xml
@@ -1,0 +1,44 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="England-Identifier-SDS-User-Id" />
+  <url value="https://fhir.nhs.uk/England/StructureDefinition/England-Identifier-SDS-User-Id" />
+  <version value="0.0.1-current" />
+  <name value="EnglandIdentifierSDSUserId" />
+  <title value="England Identifier SDS User Id" />
+  <status value="draft" />
+  <date value="2024-10-25T07:31:19+00:00" />
+  <publisher value="NHS England" />
+  <contact>
+    <name value="NHS England" />
+    <telecom>
+      <system value="email" />
+      <value value="interoperabilityteam@nhs.net" />
+      <use value="work" />
+      <rank value="1" />
+    </telecom>
+  </contact>
+  <description value="In NHS Englands Spine Directory Service this is the uid in the nhsPerson object.
+This is also [SmartCard UUID](https://digital.nhs.uk/services/care-identity-service/smartcard-and-authentication-users)
+
+MISSING formal definition of this type
+
+HL7 v3/OID: 1.2.826.0.1285.0.2.0.65" />
+  <purpose value="This documents NHS England Data Dictionary and HL7 definitions" />
+  <copyright value="Copyright © 2023+ NHS England Licensed under the Apache License, Version 2.0 (the \&amp;quot;License\&amp;quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \&amp;quot;AS IS\&amp;quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+  <fhirVersion value="4.0.1" />
+  <kind value="complex-type" />
+  <abstract value="false" />
+  <type value="Identifier" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Identifier" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Identifier.system">
+      <path value="Identifier.system" />
+      <min value="1" />
+      <patternUri value="https://fhir.nhs.uk/Id/sds-user-id" />
+    </element>
+    <element id="Identifier.value">
+      <path value="Identifier.value" />
+      <min value="1" />
+    </element>
+  </differential>
+</StructureDefinition>

--- a/structuredefinitions/England-Identifier-SDS-User-Profile-Id.xml
+++ b/structuredefinitions/England-Identifier-SDS-User-Profile-Id.xml
@@ -1,0 +1,43 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="England-Identifier-SDS-User-Profile-Id"/>
+  <url value="https://fhir.nhs.uk/England/StructureDefinition/England-Identifier-SDS-User-Profile-Id"/>
+  <version value="0.0.1-current"/>
+  <name value="EnglandIdentifierSDSUserProfileId"/>
+  <title value="England Identifier SDS User Profile Id"/>
+  <status value="draft"/>
+  <date value="2024-10-25T07:31:19+00:00"/>
+  <publisher value="NHS England"/>
+  <contact>
+    <name value="NHS England" />
+    <telecom>
+      <system value="email" />
+      <value value="interoperabilityteam@nhs.net" />
+      <use value="work" />
+      <rank value="1" />
+    </telecom>
+  </contact>
+  <purpose value="This documents NHS England Data Dictionary and HL7 definitions" />
+  <description value="In NHS Englands Spine Directory Service this is the uniqueIdentifier in the nhsOrgPerson and nhsOrgPersonRole object (confirm this is true).
+This
+MISSING formal definition of this type
+
+HL7 v3/OID: 1.2.826.0.1285.0.2.0.67"/>
+  <copyright value="Copyright © 2023+ NHS England Licensed under the Apache License, Version 2.0 (the \&amp;quot;License\&amp;quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \&amp;quot;AS IS\&amp;quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+  <fhirVersion value="4.0.1"/>
+  <kind value="complex-type"/>
+  <abstract value="false"/>
+  <type value="Identifier"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Identifier"/>
+  <derivation value="constraint"/>
+  <differential>
+    <element id="Identifier.system">
+      <path value="Identifier.system"/>
+      <min value="1"/>
+      <patternUri value="https://fhir.nhs.uk/Id/sds-role-profile-id"/>
+    </element>
+    <element id="Identifier.value">
+      <path value="Identifier.value"/>
+      <min value="1"/>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/structuredefinitions/England-Identifier-SDS-User-Profile-Id.xml
+++ b/structuredefinitions/England-Identifier-SDS-User-Profile-Id.xml
@@ -1,12 +1,12 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="England-Identifier-SDS-User-Profile-Id"/>
-  <url value="https://fhir.nhs.uk/England/StructureDefinition/England-Identifier-SDS-User-Profile-Id"/>
-  <version value="0.0.1-current"/>
-  <name value="EnglandIdentifierSDSUserProfileId"/>
-  <title value="England Identifier SDS User Profile Id"/>
-  <status value="draft"/>
-  <date value="2024-10-25T07:31:19+00:00"/>
-  <publisher value="NHS England"/>
+  <id value="England-Identifier-SDS-User-Profile-Id" />
+  <url value="https://fhir.nhs.uk/England/StructureDefinition/England-Identifier-SDS-User-Profile-Id" />
+  <version value="0.0.1-current" />
+  <name value="EnglandIdentifierSDSUserProfileId" />
+  <title value="England Identifier SDS User Profile Id" />
+  <status value="draft" />
+  <date value="2024-10-25T07:31:19+00:00" />
+  <publisher value="NHS England" />
   <contact>
     <name value="NHS England" />
     <telecom>
@@ -21,23 +21,23 @@
 This
 MISSING formal definition of this type
 
-HL7 v3/OID: 1.2.826.0.1285.0.2.0.67"/>
+HL7 v3/OID: 1.2.826.0.1285.0.2.0.67" />
   <copyright value="Copyright © 2023+ NHS England Licensed under the Apache License, Version 2.0 (the \&amp;quot;License\&amp;quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \&amp;quot;AS IS\&amp;quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
-  <fhirVersion value="4.0.1"/>
-  <kind value="complex-type"/>
-  <abstract value="false"/>
-  <type value="Identifier"/>
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Identifier"/>
-  <derivation value="constraint"/>
+  <fhirVersion value="4.0.1" />
+  <kind value="complex-type" />
+  <abstract value="false" />
+  <type value="Identifier" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Identifier" />
+  <derivation value="constraint" />
   <differential>
     <element id="Identifier.system">
-      <path value="Identifier.system"/>
-      <min value="1"/>
-      <patternUri value="https://fhir.nhs.uk/Id/sds-role-profile-id"/>
+      <path value="Identifier.system" />
+      <min value="1" />
+      <patternUri value="https://fhir.nhs.uk/Id/sds-role-profile-id" />
     </element>
     <element id="Identifier.value">
-      <path value="Identifier.value"/>
-      <min value="1"/>
+      <path value="Identifier.value" />
+      <min value="1" />
     </element>
   </differential>
 </StructureDefinition>

--- a/structuredefinitions/England-Practitioner.xml
+++ b/structuredefinitions/England-Practitioner.xml
@@ -1,0 +1,91 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+    <id value="England-Practitioner"/>
+    <url value="https://fhir.nhs.uk/England/StructureDefinition/England-Practitioner"/>
+    <version value="0.0.1-current"/>
+    <name value="EnglandPractitioner"/>
+    <title value="England Practitioner"/>
+    <status value="draft"/>
+    <date value="2024-10-25T07:31:19+00:00"/>
+    <publisher value="NHS England"/>
+    <contact>
+        <name value="NHS England" />
+        <telecom>
+            <system value="email" />
+            <value value="interoperabilityteam@nhs.net" />
+            <use value="work" />
+            <rank value="1" />
+        </telecom>
+    </contact>
+    <description value="Based on requirments from the previous NHS Digital IG and NHS Data Dictionary"/>
+    <purpose value="Documentation of requirements for NHS England Healthcare Worker API" />
+    <copyright value="Copyright © 2023+ NHS England Licensed under the Apache License, Version 2.0 (the \&amp;quot;License\&amp;quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \&amp;quot;AS IS\&amp;quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+    <fhirVersion value="4.0.1"/>
+    <kind value="resource"/>
+    <abstract value="false"/>
+    <type value="Practitioner"/>
+    <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Practitioner"/>
+    <derivation value="constraint"/>
+    <differential>
+        <element id="Practitioner.identifier">
+            <path value="Practitioner.identifier"/>
+            <slicing>
+                <discriminator>
+                    <type value="value"/>
+                    <path value="system"/>
+                </discriminator>
+                <rules value="closed"/>
+            </slicing>
+            <min value="1"/>
+        </element>
+        <element id="Practitioner.identifier.system">
+            <path value="Practitioner.identifier.system"/>
+            <min value="1"/>
+        </element>
+        <element id="Practitioner.identifier.value">
+            <path value="Practitioner.identifier.value"/>
+            <min value="1"/>
+        </element>
+        <element id="Practitioner.identifier:gmp-number">
+            <path value="Practitioner.identifier"/>
+            <sliceName value="gmp-number"/>
+            <min value="0"/>
+            <max value="1"/>
+            <type>
+                <code value="Identifier"/>
+                <profile value="https://fhir.nhs.uk/England/StructureDefinition/England-Identifier-General-Medical-Practitioner-Code"/>
+            </type>
+        </element>
+        <element id="Practitioner.identifier:gmp-number.system">
+            <path value="Practitioner.identifier.system" />
+            <fixedUri value="https://fhir.hl7.org.uk/Id/gmp-number" />
+        </element>
+        <element id="Practitioner.identifier:gmc-number">
+            <path value="Practitioner.identifier"/>
+            <sliceName value="gmc-number"/>
+            <min value="0"/>
+            <max value="1"/>
+            <type>
+                <code value="Identifier"/>
+                <profile value="https://fhir.nhs.uk/England/StructureDefinition/England-Identifier-General-Medical-Council-Reference-Number"/>
+            </type>
+        </element>
+        <element id="Practitioner.identifier:gmc-number.system">
+            <path value="Practitioner.identifier.system" />
+            <fixedUri value="https://fhir.hl7.org.uk/Id/gmc-number" />
+        </element>
+        <element id="Practitioner.identifier:sds-user-id">
+            <path value="Practitioner.identifier"/>
+            <sliceName value="sds-user-id"/>
+            <min value="0"/>
+            <max value="1"/>
+            <type>
+                <code value="Identifier"/>
+                <profile value="https://fhir.nhs.uk/England/StructureDefinition/England-Identifier-SDS-User-Id"/>
+            </type>
+        </element>
+        <element id="Practitioner.identifier:sds-user-id.system">
+            <path value="Practitioner.identifier.system" />
+            <fixedUri value="https://fhir.nhs.uk/Id/sds-user-id" />
+        </element>
+    </differential>
+</StructureDefinition>

--- a/structuredefinitions/England-Practitioner.xml
+++ b/structuredefinitions/England-Practitioner.xml
@@ -1,12 +1,12 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
-    <id value="England-Practitioner"/>
-    <url value="https://fhir.nhs.uk/England/StructureDefinition/England-Practitioner"/>
-    <version value="0.0.1-current"/>
-    <name value="EnglandPractitioner"/>
-    <title value="England Practitioner"/>
-    <status value="draft"/>
-    <date value="2024-10-25T07:31:19+00:00"/>
-    <publisher value="NHS England"/>
+    <id value="England-Practitioner" />
+    <url value="https://fhir.nhs.uk/England/StructureDefinition/England-Practitioner" />
+    <version value="0.0.1-current" />
+    <name value="EnglandPractitioner" />
+    <title value="England Practitioner" />
+    <status value="draft" />
+    <date value="2024-10-25T07:31:19+00:00" />
+    <publisher value="NHS England" />
     <contact>
         <name value="NHS England" />
         <telecom>
@@ -16,43 +16,43 @@
             <rank value="1" />
         </telecom>
     </contact>
-    <description value="Based on requirments from the previous NHS Digital IG and NHS Data Dictionary"/>
+    <description value="Based on requirments from the previous NHS Digital IG and NHS Data Dictionary" />
     <purpose value="Documentation of requirements for NHS England Healthcare Worker API" />
     <copyright value="Copyright © 2023+ NHS England Licensed under the Apache License, Version 2.0 (the \&amp;quot;License\&amp;quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \&amp;quot;AS IS\&amp;quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
-    <fhirVersion value="4.0.1"/>
-    <kind value="resource"/>
-    <abstract value="false"/>
-    <type value="Practitioner"/>
-    <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Practitioner"/>
-    <derivation value="constraint"/>
+    <fhirVersion value="4.0.1" />
+    <kind value="resource" />
+    <abstract value="false" />
+    <type value="Practitioner" />
+    <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Practitioner" />
+    <derivation value="constraint" />
     <differential>
         <element id="Practitioner.identifier">
-            <path value="Practitioner.identifier"/>
+            <path value="Practitioner.identifier" />
             <slicing>
                 <discriminator>
-                    <type value="value"/>
-                    <path value="system"/>
+                    <type value="value" />
+                    <path value="system" />
                 </discriminator>
-                <rules value="closed"/>
+                <rules value="closed" />
             </slicing>
-            <min value="1"/>
+            <min value="1" />
         </element>
         <element id="Practitioner.identifier.system">
-            <path value="Practitioner.identifier.system"/>
-            <min value="1"/>
+            <path value="Practitioner.identifier.system" />
+            <min value="1" />
         </element>
         <element id="Practitioner.identifier.value">
-            <path value="Practitioner.identifier.value"/>
-            <min value="1"/>
+            <path value="Practitioner.identifier.value" />
+            <min value="1" />
         </element>
         <element id="Practitioner.identifier:gmp-number">
-            <path value="Practitioner.identifier"/>
-            <sliceName value="gmp-number"/>
-            <min value="0"/>
-            <max value="1"/>
+            <path value="Practitioner.identifier" />
+            <sliceName value="gmp-number" />
+            <min value="0" />
+            <max value="1" />
             <type>
-                <code value="Identifier"/>
-                <profile value="https://fhir.nhs.uk/England/StructureDefinition/England-Identifier-General-Medical-Practitioner-Code"/>
+                <code value="Identifier" />
+                <profile value="https://fhir.nhs.uk/England/StructureDefinition/England-Identifier-General-Medical-Practitioner-Code" />
             </type>
         </element>
         <element id="Practitioner.identifier:gmp-number.system">
@@ -60,13 +60,13 @@
             <fixedUri value="https://fhir.hl7.org.uk/Id/gmp-number" />
         </element>
         <element id="Practitioner.identifier:gmc-number">
-            <path value="Practitioner.identifier"/>
-            <sliceName value="gmc-number"/>
-            <min value="0"/>
-            <max value="1"/>
+            <path value="Practitioner.identifier" />
+            <sliceName value="gmc-number" />
+            <min value="0" />
+            <max value="1" />
             <type>
-                <code value="Identifier"/>
-                <profile value="https://fhir.nhs.uk/England/StructureDefinition/England-Identifier-General-Medical-Council-Reference-Number"/>
+                <code value="Identifier" />
+                <profile value="https://fhir.nhs.uk/England/StructureDefinition/England-Identifier-General-Medical-Council-Reference-Number" />
             </type>
         </element>
         <element id="Practitioner.identifier:gmc-number.system">
@@ -74,13 +74,13 @@
             <fixedUri value="https://fhir.hl7.org.uk/Id/gmc-number" />
         </element>
         <element id="Practitioner.identifier:sds-user-id">
-            <path value="Practitioner.identifier"/>
-            <sliceName value="sds-user-id"/>
-            <min value="0"/>
-            <max value="1"/>
+            <path value="Practitioner.identifier" />
+            <sliceName value="sds-user-id" />
+            <min value="0" />
+            <max value="1" />
             <type>
-                <code value="Identifier"/>
-                <profile value="https://fhir.nhs.uk/England/StructureDefinition/England-Identifier-SDS-User-Id"/>
+                <code value="Identifier" />
+                <profile value="https://fhir.nhs.uk/England/StructureDefinition/England-Identifier-SDS-User-Id" />
             </type>
         </element>
         <element id="Practitioner.identifier:sds-user-id.system">

--- a/structuredefinitions/England-PractitionerRole-Healthcare-Worker.xml
+++ b/structuredefinitions/England-PractitionerRole-Healthcare-Worker.xml
@@ -1,12 +1,12 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="England-PractitionerRole-Healthcare-Worker"/>
-  <url value="https://fhir.nhs.uk/England/StructureDefinition/England-PractitionerRole-Healthcare-Worker"/>
-  <version value="0.0.1-current"/>
-  <name value="EnglandPractitionerRoleHealthcareWorker"/>
-  <title value="England Practitioner Role Healthcare Worker"/>
-  <status value="draft"/>
-  <date value="2024-10-25T07:31:19+00:00"/>
-  <publisher value="NHS England"/>
+  <id value="England-PractitionerRole-Healthcare-Worker" />
+  <url value="https://fhir.nhs.uk/England/StructureDefinition/England-PractitionerRole-Healthcare-Worker" />
+  <version value="0.0.1-current" />
+  <name value="EnglandPractitionerRoleHealthcareWorker" />
+  <title value="England Practitioner Role Healthcare Worker" />
+  <status value="draft" />
+  <date value="2024-10-25T07:31:19+00:00" />
+  <publisher value="NHS England" />
   <contact>
     <name value="NHS England" />
     <telecom>
@@ -16,80 +16,80 @@
       <rank value="1" />
     </telecom>
   </contact>
-  <description value="Based on requirments from the previous NHS Digital IG and NHS Data Dictionary"/>
+  <description value="Based on requirments from the previous NHS Digital IG and NHS Data Dictionary" />
   <purpose value="Documentation of requirements for NHS England Healthcare Worker API" />
   <copyright value="Copyright © 2023+ NHS England Licensed under the Apache License, Version 2.0 (the \&amp;quot;License\&amp;quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \&amp;quot;AS IS\&amp;quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
-  <fhirVersion value="4.0.1"/>
-  <kind value="resource"/>
-  <abstract value="false"/>
-  <type value="PractitionerRole"/>
-  <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-PractitionerRole"/>
-  <derivation value="constraint"/>
+  <fhirVersion value="4.0.1" />
+  <kind value="resource" />
+  <abstract value="false" />
+  <type value="PractitionerRole" />
+  <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-PractitionerRole" />
+  <derivation value="constraint" />
   <differential>
     <element id="PractitionerRole">
-      <path value="PractitionerRole"/>
+      <path value="PractitionerRole" />
     </element>
     <element id="PractitionerRole.identifier">
-      <path value="PractitionerRole.identifier"/>
+      <path value="PractitionerRole.identifier" />
       <slicing>
         <discriminator>
-          <type value="pattern"/>
-          <path value="system"/>
+          <type value="pattern" />
+          <path value="system" />
         </discriminator>
-        <rules value="closed"/>
+        <rules value="closed" />
       </slicing>
-      <min value="1"/>
-      <mustSupport value="true"/>
+      <min value="1" />
+      <mustSupport value="true" />
     </element>
     <element id="PractitionerRole.identifier.system">
-      <path value="PractitionerRole.identifier.system"/>
-      <min value="1"/>
+      <path value="PractitionerRole.identifier.system" />
+      <min value="1" />
     </element>
     <element id="PractitionerRole.identifier.value">
-      <path value="PractitionerRole.identifier.value"/>
-      <min value="1"/>
+      <path value="PractitionerRole.identifier.value" />
+      <min value="1" />
     </element>
     <element id="PractitionerRole.identifier:sds-user-profile-id">
-      <path value="PractitionerRole.identifier"/>
-      <sliceName value="sds-user-profile-id"/>
-      <min value="1"/>
-      <max value="1"/>
+      <path value="PractitionerRole.identifier" />
+      <sliceName value="sds-user-profile-id" />
+      <min value="1" />
+      <max value="1" />
       <type>
-        <code value="Identifier"/>
-        <profile value="https://fhir.nhs.uk/England/StructureDefinition/England-Identifier-SDS-User-Profile-Id"/>
+        <code value="Identifier" />
+        <profile value="https://fhir.nhs.uk/England/StructureDefinition/England-Identifier-SDS-User-Profile-Id" />
       </type>
     </element>
     <element id="PractitionerRole.period.start">
-      <path value="PractitionerRole.period.start"/>
-      <mustSupport value="true"/>
+      <path value="PractitionerRole.period.start" />
+      <mustSupport value="true" />
     </element>
     <element id="PractitionerRole.period.end">
-      <path value="PractitionerRole.period.end"/>
-      <mustSupport value="true"/>
+      <path value="PractitionerRole.period.end" />
+      <mustSupport value="true" />
     </element>
     <element id="PractitionerRole.practitioner.identifier">
-      <path value="PractitionerRole.practitioner.identifier"/>
-      <min value="0"/>
+      <path value="PractitionerRole.practitioner.identifier" />
+      <min value="0" />
       <type>
-        <code value="Identifier"/>
+        <code value="Identifier" />
         <profile value="https://fhir.nhs.uk/England/StructureDefinition/England-Identifier-General-Medical-Practitioner-Code" />
         <profile value="https://fhir.nhs.uk/England/StructureDefinition/England-Identifier-General-Medical-Council-Reference-Number" />
         <profile value="https://fhir.nhs.uk/England/StructureDefinition/England-Identifier-SDS-User-Id" />
       </type>
     </element>
     <element id="PractitionerRole.organization.identifier">
-      <path value="PractitionerRole.organization.identifier"/>
-      <min value="1"/>
+      <path value="PractitionerRole.organization.identifier" />
+      <min value="1" />
       <type>
-        <code value="Identifier"/>
-        <profile value="https://fhir.nhs.uk/England/StructureDefinition/England-Identifier-Organisation-Code"/>
+        <code value="Identifier" />
+        <profile value="https://fhir.nhs.uk/England/StructureDefinition/England-Identifier-Organisation-Code" />
       </type>
     </element>
     <element id="PractitionerRole.code">
-      <path value="PractitionerRole.code"/>
+      <path value="PractitionerRole.code" />
       <binding>
-        <strength value="required"/>
-        <valueSet value="https://fhir.nhs.uk/England/ValueSet/England-JobRoleCode"/>
+        <strength value="required" />
+        <valueSet value="https://fhir.nhs.uk/England/ValueSet/England-JobRoleCode" />
       </binding>
     </element>
   </differential>

--- a/structuredefinitions/England-PractitionerRole-Healthcare-Worker.xml
+++ b/structuredefinitions/England-PractitionerRole-Healthcare-Worker.xml
@@ -1,0 +1,96 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="England-PractitionerRole-Healthcare-Worker"/>
+  <url value="https://fhir.nhs.uk/England/StructureDefinition/England-PractitionerRole-Healthcare-Worker"/>
+  <version value="0.0.1-current"/>
+  <name value="EnglandPractitionerRoleHealthcareWorker"/>
+  <title value="England Practitioner Role Healthcare Worker"/>
+  <status value="draft"/>
+  <date value="2024-10-25T07:31:19+00:00"/>
+  <publisher value="NHS England"/>
+  <contact>
+    <name value="NHS England" />
+    <telecom>
+      <system value="email" />
+      <value value="interoperabilityteam@nhs.net" />
+      <use value="work" />
+      <rank value="1" />
+    </telecom>
+  </contact>
+  <description value="Based on requirments from the previous NHS Digital IG and NHS Data Dictionary"/>
+  <purpose value="Documentation of requirements for NHS England Healthcare Worker API" />
+  <copyright value="Copyright © 2023+ NHS England Licensed under the Apache License, Version 2.0 (the \&amp;quot;License\&amp;quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \&amp;quot;AS IS\&amp;quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+  <fhirVersion value="4.0.1"/>
+  <kind value="resource"/>
+  <abstract value="false"/>
+  <type value="PractitionerRole"/>
+  <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-PractitionerRole"/>
+  <derivation value="constraint"/>
+  <differential>
+    <element id="PractitionerRole">
+      <path value="PractitionerRole"/>
+    </element>
+    <element id="PractitionerRole.identifier">
+      <path value="PractitionerRole.identifier"/>
+      <slicing>
+        <discriminator>
+          <type value="pattern"/>
+          <path value="system"/>
+        </discriminator>
+        <rules value="closed"/>
+      </slicing>
+      <min value="1"/>
+      <mustSupport value="true"/>
+    </element>
+    <element id="PractitionerRole.identifier.system">
+      <path value="PractitionerRole.identifier.system"/>
+      <min value="1"/>
+    </element>
+    <element id="PractitionerRole.identifier.value">
+      <path value="PractitionerRole.identifier.value"/>
+      <min value="1"/>
+    </element>
+    <element id="PractitionerRole.identifier:sds-user-profile-id">
+      <path value="PractitionerRole.identifier"/>
+      <sliceName value="sds-user-profile-id"/>
+      <min value="1"/>
+      <max value="1"/>
+      <type>
+        <code value="Identifier"/>
+        <profile value="https://fhir.nhs.uk/England/StructureDefinition/England-Identifier-SDS-User-Profile-Id"/>
+      </type>
+    </element>
+    <element id="PractitionerRole.period.start">
+      <path value="PractitionerRole.period.start"/>
+      <mustSupport value="true"/>
+    </element>
+    <element id="PractitionerRole.period.end">
+      <path value="PractitionerRole.period.end"/>
+      <mustSupport value="true"/>
+    </element>
+    <element id="PractitionerRole.practitioner.identifier">
+      <path value="PractitionerRole.practitioner.identifier"/>
+      <min value="0"/>
+      <type>
+        <code value="Identifier"/>
+        <profile value="https://fhir.nhs.uk/England/StructureDefinition/England-Identifier-General-Medical-Practitioner-Code" />
+        <profile value="https://fhir.nhs.uk/England/StructureDefinition/England-Identifier-General-Medical-Council-Reference-Number" />
+        <profile value="https://fhir.nhs.uk/England/StructureDefinition/England-Identifier-SDS-User-Id" />
+      </type>
+    </element>
+    <element id="PractitionerRole.organization.identifier">
+      <path value="PractitionerRole.organization.identifier"/>
+      <min value="1"/>
+      <type>
+        <code value="Identifier"/>
+        <profile value="https://fhir.nhs.uk/England/StructureDefinition/England-Identifier-Organisation-Code"/>
+      </type>
+    </element>
+    <element id="PractitionerRole.code">
+      <path value="PractitionerRole.code"/>
+      <binding>
+        <strength value="required"/>
+        <valueSet value="https://fhir.nhs.uk/England/ValueSet/England-JobRoleCode"/>
+      </binding>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/valuesets/ValueSet-England-JobRoleCode.json
+++ b/valuesets/ValueSet-England-JobRoleCode.json
@@ -22,7 +22,7 @@
             ]
         }
     ],
-    "description": "- [JOB ROLE CODE](https://www.datadictionary.nhs.uk/attributes/job_role_code.html)\n- [UKCoreSDSJobRoleName](https://simplifier.net/hl7fhirukcorer4/codesystem-ukcore-sdsjobrolename)",
+    "description": "TODO Reduce CodeSystems allowed in this valueset, http://terminology.hl7.org/CodeSystem/practitioner-role is included to not invalidate DOS examples and ideally should be removed. \n- [JOB ROLE CODE](https://www.datadictionary.nhs.uk/attributes/job_role_code.html)\n- [UKCoreSDSJobRoleName](https://simplifier.net/hl7fhirukcorer4/codesystem-ukcore-sdsjobrolename)",
     "compose": {
         "include": [
             {

--- a/valuesets/ValueSet-England-JobRoleCode.json
+++ b/valuesets/ValueSet-England-JobRoleCode.json
@@ -1,0 +1,39 @@
+{
+    "resourceType": "ValueSet",
+    "id": "England-JobRoleCode",
+    "url": "https://fhir.nhs.uk/England/ValueSet/England-JobRoleCode",
+    "version": "0.0.1-current",
+    "name": "EnglandJobRoleCode",
+    "title": "England Job Role Code",
+    "status": "draft",
+    "date": "2024-10-25T07:31:19+00:00",
+    "publisher": "NHS England",
+    "copyright": "Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the \"License\"); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html.",
+    "contact": [
+        {
+            "name": "NHS England",
+            "telecom": [
+                {
+                    "system": "email",
+                    "value": "interoperabilityteam@nhs.net",
+                    "use": "work",
+                    "rank": 1
+                }
+            ]
+        }
+    ],
+    "description": "- [JOB ROLE CODE](https://www.datadictionary.nhs.uk/attributes/job_role_code.html)\n- [UKCoreSDSJobRoleName](https://simplifier.net/hl7fhirukcorer4/codesystem-ukcore-sdsjobrolename)",
+    "compose": {
+        "include": [
+            {
+                "system": "http://terminology.hl7.org/CodeSystem/practitioner-role"
+            },
+            {
+                "system": "https://fhir.nhs.uk/England/CodeSystem/England-SDSJobRoleName"
+            },
+            {
+                "system": "https://fhir.nhs.uk/England/CodeSystem/England-JobRoleCode"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Copy of assets for Healthcare Worker API (which was being elaborated as an igPublisher IG). 

This is using a core set of assets which are also in National Proxy Service PR https://github.com/NHSDigital/NHSEngland-FHIR-Programme-ImplementationGuide/pull/104 and so will likely cause some merging.  These are mostly profiles on Identifier.


