### PR TITLE
Update options.json

### DIFF
--- a/options.json
+++ b/options.json
@@ -1,5 +1,5 @@
 { 
- "strict-validation": true, 
+ "strict-validation": false, 
  "ignore-folders": [], 
  "ignore-files": [], 
  "error-if-metaProfile-present": false 


### PR DESCRIPTION
Warnings are currently promoted to errors, but do to complexity and requirements of programmes, these sometimes do not want be fixed. To allow the Validator to not fail and stop merging this sets all warnings to stay as warnings.