### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "version": "0.0.1",
   "dependencies": {
     "hl7.fhir.r4.core": "4.0.1",
+    "fhir.tx.support.r4": "0.27.0",
     "fhir.r4.nhsengland.stu1": "1.3.0",
     "fhir.r4.ukcore.stu3.currentbuild": "0.0.18-pre-release",
     "hl7.fhir.uv.sdc": "3.0.0",


### PR DESCRIPTION
added fhir.tx.support.r4#0.27.0 which allows terminology support for external codesystems

https://www.fhir.org/packages/fhir.tx.support.r4/