### PR TITLE
added fhirpkg.lock.json to ignore list as this comes from Forge and is…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ structuredefinitions/fhirpkg.lock.json
 structuredefinitions/.simplifier/folder.settings.json
 .simplifier/folder.settings.json
 .idea/
+.fhirpkg.lock.json

--- a/fhirpkg.lock.json
+++ b/fhirpkg.lock.json
@@ -1,9 +1,0 @@
-{
-  "updated": "2024-03-19T14:03:52.4547989+00:00",
-  "dependencies": {
-    "hl7.fhir.r4.core": "4.0.1",
-    "fhir.r4.nhsengland.stu1": "1.1.0",
-    "fhir.r4.ukcore.stu3.currentbuild": "0.0.6-pre-release"
-  },
-  "missing": {}
-}


### PR DESCRIPTION
… not needed here. fhirpkg.lock.josn is created by npm when ran. We are using package.json for the validation service