### PR TITLE
Fix national screening validation

### DIFF
--- a/examples/National-Screening-Breast-Screening-Cohort-Example.xml
+++ b/examples/National-Screening-Breast-Screening-Cohort-Example.xml
@@ -340,11 +340,23 @@
         <code value="110100" /> 
         <display value="Application Activity" /> 
       </type> 
+      <action value="C" />
       <recorded value="2012-10-25T22:04:27+11:00" /> 
       <agent>
                 <who>
                     <reference value="urn:uuid:c1f6c9be-fd9a-4a73-9e65-d9fbb5676d04" />
+                    <identifier>
+                      <system value="https://fhir.hl7.org.uk/Id/gmp-number" />
+                      <value value="G823658" />
+                    </identifier>
                 </who>
+          <type>
+            <coding>
+              <system value="http://terminology.hl7.org/CodeSystem/v3-RoleClass" /> 
+              <code value="PROV" /> 
+              <display value="healthcare provider" /> 
+            </coding>
+          </type>
           <requestor value="false" />
       </agent> 
       <source> 

--- a/examples/National-Screening-Breast-Screening-Cohort-Example.xml
+++ b/examples/National-Screening-Breast-Screening-Cohort-Example.xml
@@ -58,8 +58,8 @@
         <communication>
       <language>
         <coding>
-        <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-HumanLanguage" />
-        <code value="en" />
+        <system value="urn:ietf:bcp:47" />
+        <code value="en-GB" />
         <display value="English" />
         </coding>
       </language>

--- a/examples/National-Screening-Breast-Screening-Cohort-Example.xml
+++ b/examples/National-Screening-Breast-Screening-Cohort-Example.xml
@@ -312,7 +312,7 @@
                     <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Practitioner" />
                 </meta>
                 <identifier>
-                    <system value="https://fhir.nhs.uk/Id/sds-role-profile-id" />
+                    <system value="https://fhir.hl7.org.uk/Id/gmp-number" />
                     <value value="G823658" />
                 </identifier>
                 <name>

--- a/examples/National-Screening-Breast-Screening-Cohort-Example.xml
+++ b/examples/National-Screening-Breast-Screening-Cohort-Example.xml
@@ -349,14 +349,8 @@
                       <system value="https://fhir.hl7.org.uk/Id/gmp-number" />
                       <value value="G823658" />
                     </identifier>
+                    <type value="Practitioner" />
                 </who>
-          <type>
-            <coding>
-              <system value="http://terminology.hl7.org/CodeSystem/v3-RoleClass" /> 
-              <code value="PROV" /> 
-              <display value="healthcare provider" /> 
-            </coding>
-          </type>
           <requestor value="false" />
       </agent> 
       <source> 


### PR DESCRIPTION
Example of fixes for validation.

I agree with the validation errors regarding language and practitioner id, as the old language valueset is no longer conformant to UK Core and the sds role profile id is an identifier for a PractitionerRole, not a practitioner. 

The AuditEvent constraints could be argued against, as there is no need to specify the type and identifier if you have a concrete reference, though I would argue for the action being required as this details the actual event the AuditEvent is recording.